### PR TITLE
CRAN requirement adjustments

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -44,12 +44,11 @@ create_template <- function (directory, template_name, bib.location, launch_temp
 
     if (answer %in% c("Y","y")) {
       cat("Creating folder and executing Tex Platform creation")
-
       sink(tempfile())
       Sys.sleep(1)
           # unlink(list.files(directory, full.names = TRUE), recursive = TRUE)
           dir.create(paste0(directory,"\\template"), showWarnings = FALSE)
-          directory <<- paste0(directory,"\\template")
+          directory <- paste0(directory,"\\template")
       } else {
         return(cat("!Template not created!"))
       }
@@ -101,11 +100,11 @@ create_template <- function (directory, template_name, bib.location, launch_temp
                             to = paste0( file.path(directory, template_name), ".Rmd"))
   }
 
+# Creating template
   if (launch_template) {
     library(rmarkdown)
-    WD <- getwd()
-    on.exit(setwd(WD))
     setwd(directory)
+    on.exit(setwd(directory))
     rmarkdown::render(paste0(file.path(directory, template_name), ".Rmd"),
                       output_format = "pdf_document",
                       envir = new.env())

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -15,9 +15,9 @@
 create_template <- function (directory, template_name, bib.location, launch_template = TRUE) {
 
   sink(tempfile())
-  
-  ifelse(!require(devtools, quietly = T), stop("Devtools library not found"), FALSE)
-  
+
+  ifelse(!require(devtools, quietly = T), return(cat("Devtools library not found")), FALSE)
+
   tex.file.root <- system.file("Tex", package = "Texevier")
   rmd.file.root <- system.file("Template", package = "Texevier")
   data.file.root <- system.file("Data", package = "Texevier")
@@ -29,21 +29,29 @@ create_template <- function (directory, template_name, bib.location, launch_temp
   if (missing(template_name)) {
     template_name <- "Template"
   }
-  
+
   sink()
-  
+
   if (file.exists(directory)) {
-    answer <- readline(cat("--------------- \n PROMPT: \n \n Path: ", file.path(directory), " provided already exists. \n Proceed to create template in this folder? Type: Y or N....\n"))
+    answer <- readline(cat("--------------- \n PROMPT: \n \n Path: ",
+                           file.path(directory), " provided already exists. \n Proceed to create template in this folder? Type: Y or N....\n"))
+
+    while(!(answer %in% c("Y", "y", "N", "n")))
+    {
+      answer <- readline(cat("--------------- \n PROMPT: \n---------------\n Invalid input, please type Y in order to create template folder in path: ",
+                             file.path(directory)," OR type N to quit \n"))
+    }
+
     if (answer %in% c("Y","y")) {
       cat("Creating folder and executing Tex Platform creation")
-      
+
       sink(tempfile())
       Sys.sleep(1)
           # unlink(list.files(directory, full.names = TRUE), recursive = TRUE)
           dir.create(paste0(directory,"\\template"), showWarnings = FALSE)
           directory <<- paste0(directory,"\\template")
       } else {
-        stop("No Template Created")
+        return(cat("!Template not created!"))
       }
   } else {
     sink(tempfile())
@@ -55,7 +63,7 @@ create_template <- function (directory, template_name, bib.location, launch_temp
     }
       ifelse(!dir.exists(directory), mkdirs(directory), FALSE)
   }
-  
+
 
 # Create and save tex templates:
   dir.create(file.path(directory, "Tex"), showWarnings = FALSE)
@@ -67,7 +75,7 @@ create_template <- function (directory, template_name, bib.location, launch_temp
     sink()
     stop(cat(paste0("\n bib file: \n", bib.location," \n does not exist. Leave this parameter blank to create default .bibfile, or check bib.location provided.")))
   }
-  
+
   if (missing(bib.location)) {
 # Fetch and store templates:
     file.copy (list.files(tex.file.root, full.names = TRUE), to = file.path(directory, "Tex"))
@@ -82,7 +90,7 @@ create_template <- function (directory, template_name, bib.location, launch_temp
     file.rename(from = list.files(file.path(directory, "Tex") , full.names = TRUE)[grepl(bib_name,list.files(tex.file.root, full.names = TRUE))],
                 to = paste0(file.path(directory, "Tex"), "/refs.bib"))
   }
-# Fetch template code and Data  
+# Fetch template code and Data
   file.copy (list.files(data.file.root, full.names = TRUE), to = file.path(directory, "Data"))
   file.copy (list.files(code.file.root, full.names = TRUE), to = file.path(directory, "Code"))
 

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -103,6 +103,8 @@ create_template <- function (directory, template_name, bib.location, launch_temp
 # Creating template
   if (launch_template) {
     library(rmarkdown)
+    WD <- getwd()		
+    on.exit(setwd(WD))
     setwd(directory)
     on.exit(setwd(directory))
     rmarkdown::render(paste0(file.path(directory, template_name), ".Rmd"),

--- a/inst/Template/Template.Rmd
+++ b/inst/Template/Template.Rmd
@@ -46,6 +46,8 @@ output:
     template: Tex/TexDefault.txt
     fig_width: 3.5 # Adjust default figure sizes. This can also be done in the chunks of the text.
     fig_height: 3.5
+    include:
+      in_header: Tex/packages.txt # Reference file with extra packages
 abstract: |
   Abstract to be written here. The abstract should not be too long and should provide the reader with a good understanding what you are writing about. Academic papers are not like novels where you keep the reader in suspense. To be effective in getting others to read your paper, be as open and concise about your findings here as possible. Ideally, upon reading your abstract, the reader should feel he / she must read your paper in entirety.
 ---

--- a/inst/Tex/TexDefault.txt
+++ b/inst/Tex/TexDefault.txt
@@ -1,4 +1,5 @@
 ﻿\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$preprint, authoryear]{$documentclass$}
+
 \usepackage{lmodern}
 %%%% My spacing
 \usepackage{setspace}
@@ -57,9 +58,7 @@ $if(mathfont)$
 $endif$
 \fi
 
-
-
-\usepackage{amssymb,amsmath}
+\usepackage{amssymb, amsmath, amsthm, amsfonts}
 
 \usepackage[round]{natbib}
 \bibliographystyle{natbib}
@@ -138,6 +137,11 @@ $endif$
 \let\rmarkdownfootnote\footnote%
 \def\footnote{\protect\rmarkdownfootnote}
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+
+%%% Include extra packages specified by user
+$if(header-includes)$
+$header-includes$
+$endif$
 
 \begin{document}
 

--- a/inst/Tex/packages.txt
+++ b/inst/Tex/packages.txt
@@ -1,0 +1,2 @@
+% Insert custom packages here as follows
+% \usepackage{tikz}


### PR DESCRIPTION
**Previous**
Used `sink()` in previous update so that we don't have to enclose message generating functions in `invisible()` the whole time. NB - don't know CRAN's view on this

**This** session update
- Updated `PROMPT` with `while` loop to force correct input `Y` or `N`
- Removed `exit` command `stop` with `return` in order to spec package to CRAN requirements. This is because `stop` is an error generating function -> CRAN uploads require no `errors` being generated. The correct specification to exit function in `return()`
